### PR TITLE
Ensure pages are async server components

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -2,7 +2,7 @@
 
 import CreatePageForm from '@/components/CreatePageForm';
 
-export default function CreatePage() {
+export default async function CreatePage() {
   return (
     <main className="p-4">
       <h1>Pagina voor het kraambezoek aanmaken</h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
   description: 'Plan visiting hours',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { Button } from 'primereact/button';
 
-export default function Home() {
+export default async function Home() {
   return (
     <main
       className="min-h-screen flex flex-col items-center justify-center text-center p-4"

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,4 +1,4 @@
-import { Page, Visit, addVisit as saveVisit } from '@/services/pageService';
+import type { Page, Visit } from '@/services/pageService';
 
 export class Calendar {
   private page: Page;
@@ -139,11 +139,6 @@ export class Calendar {
     }
     if (this.isPeriodFull(date, time)) return 'full';
     return 'available';
-  }
-
-  async addVisit(date: string, time: string, name: string) {
-    const visit = await saveVisit(this.page.reference, { date, time, name });
-    return visit;
   }
 
   static timeAddMinutes(time: string, addMinutes: number) {


### PR DESCRIPTION
## Summary
- make top-level layout and pages `async` server components
- keep database interactions server-side by removing stray access from calendar utility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68bddbe4033883209feb3467ebba37b0