### PR TITLE
Fix certbot installation for HTTPS

### DIFF
--- a/.ebextensions/00_install_certbot.config
+++ b/.ebextensions/00_install_certbot.config
@@ -1,17 +1,7 @@
 container_commands:
-    00_download_epel:
-        command: "sudo wget -r --no-parent -A 'epel-release-*.rpm' http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/"
-        ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
-    10_install_epel_release:
-        command: "sudo rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm"
-        ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
-    20_enable_epel:
-        command: "sudo yum-config-manager --enable epel*"
-        ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
-    30_install_certbot:
-        command: "sudo yum install -y certbot python2-certbot-apache"
-        ignoreErrors: true
-        test: test ! -d "/etc/letsencrypt/"
+    00_enable_epel:
+        command: "sudo amazon-linux-extras install -y epel"
+        test: test ! -f "/usr/bin/certbot"
+    10_install_certbot:
+        command: "sudo yum install -y certbot python3-certbot-apache"
+        test: test ! -f "/usr/bin/certbot"

--- a/.platform/hooks/postdeploy/00_get_certificate.sh
+++ b/.platform/hooks/postdeploy/00_get_certificate.sh
@@ -7,5 +7,9 @@ test -e /etc/httpd/conf.d/virtual-host.conf || cat <<EOT | sudo tee /etc/httpd/c
 </VirtualHost>
 EOT
 
-sudo certbot -n -d opkraambezoek.nl,www.opkraambezoek.nl --apache --agree-tos --email arnold@jasny.net
+if command -v certbot >/dev/null 2>&1; then
+  sudo certbot -n -d opkraambezoek.nl,www.opkraambezoek.nl --apache --redirect --agree-tos --email arnold@jasny.net
+else
+  echo "certbot not installed" >&2
+fi
 


### PR DESCRIPTION
## Summary
- replace obsolete certbot install steps with amazon-linux-extras and python3 packages
- ensure post-deploy hook checks for certbot and enables HTTPS redirect

## Testing
- `bash -n .platform/hooks/postdeploy/00_get_certificate.sh`
- `python - <<'PY'
import yaml,sys
yaml.safe_load(open('.ebextensions/00_install_certbot.config'))
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c0a5d5b55083208063df9f58e1a880